### PR TITLE
Change read API according to the amends made in #38

### DIFF
--- a/docs/api/programme.md
+++ b/docs/api/programme.md
@@ -133,7 +133,7 @@ A collection of the possible programmes.
     "class": [ "collection", "programme" ],
     "entities": [
         {
-            "class": [ "Programme" ],
+            "class": [ "programme" ],
             "rel": [ "item" ],
             "properties": {
                 "programmeId": 1,
@@ -144,7 +144,7 @@ A collection of the possible programmes.
             ]
         },
         {
-            "class": [ "Programme" ],
+            "class": [ "programme" ],
             "rel": [ "item" ],
             "properties": {
                 "id": 2,


### PR DESCRIPTION
Siren `class` field is now lower case for the Programme resource for
consistency.

Closes #66 