### PR TITLE
ProgrammeOffer reduced representation includes the Offer ID as a property

### DIFF
--- a/docs/api/programme.md
+++ b/docs/api/programme.md
@@ -50,6 +50,7 @@ A programme is composed by a set of _offers_.
             "title": "LS Offer",
             "rel": [ "/rel/programmeOffer" ],
             "properties": {
+                "id": 1,
                 "courseId": 2,
                 "termNumber": 3
             },
@@ -62,6 +63,7 @@ A programme is composed by a set of _offers_.
             "title": "AED Offer",
             "rel": [ "/rel/programmeOffer" ],
             "properties": {
+                "id": 2,
                 "CourseId": 5,
                 "TermNumber": 3
             },
@@ -74,6 +76,7 @@ A programme is composed by a set of _offers_.
             "title": "POO Offer",
             "rel": [ "/rel/programmeOffer" ],
             "properties": {
+                "id": 3,
                 "CourseId": 4,
                 "TermNumber": 1
             },

--- a/project/src/main/kotlin/org/ionproject/core/programme/representations/ProgrammeDetailRepr.kt
+++ b/project/src/main/kotlin/org/ionproject/core/programme/representations/ProgrammeDetailRepr.kt
@@ -10,7 +10,7 @@ import org.springframework.http.HttpMethod
  */
 data class ShortProgrammeReprWithoutOffer(val id: Int, val name: String? = null, val acronym: String, val termSize: Int)
 
-data class ShortOfferRepr(val courseId: Int, val termNumber: Int)
+data class ShortOfferRepr(val id: Int, val courseId: Int, val termNumber: Int)
 
 /**
  * Builds the Siren representations
@@ -53,7 +53,7 @@ fun Programme.programmeToDetailRepr() =
         .toSiren()
 
 private fun Programme.buildSubentities(offer: ProgrammeOffer): EmbeddedRepresentation =
-    SirenBuilder(ShortOfferRepr(offer.courseId, offer.termNumber))
+    SirenBuilder(ShortOfferRepr(offer.id, offer.courseId, offer.termNumber))
         .klass("offer")
         .title("${offer.courseAcr} Offer")
         .rel(Uri.relProgrammeOffer)

--- a/project/src/test/kotlin/org/ionproject/core/programme/ProgrammeControllerTest.kt
+++ b/project/src/test/kotlin/org/ionproject/core/programme/ProgrammeControllerTest.kt
@@ -34,11 +34,11 @@ internal class ProgrammeControllerTest : ControllerTester() {
         val selfHref = Uri.forProgrammesById(p.id)
 
         data class OutputModel(val id: Int, val name: String? = null, val acronym: String, val termSize: Int)
-        data class ItemOutputModel(val courseId: Int, val termNumber: Int)
+        data class ItemOutputModel(val id: Int, val courseId: Int, val termNumber: Int)
 
         val expected = SirenBuilder(OutputModel(p.id, p.name, p.acronym, p.termSize))
             .entities(p.offers.map {
-                SirenBuilder(ItemOutputModel(it.courseId, it.termNumber))
+                SirenBuilder(ItemOutputModel(it.id, it.courseId, it.termNumber))
                     .klass("offer")
                     .title("${it.courseAcr} Offer")
                     .rel(Uri.relProgrammeOffer)


### PR DESCRIPTION
This will help clients cache the Offers without extra roundtrips. 

Closes #73 