### PR TITLE
Bug fix: orders class sections in a class resource's full representation

### DIFF
--- a/project/src/main/kotlin/org/ionproject/core/klass/sql/KlassData.kt
+++ b/project/src/main/kotlin/org/ionproject/core/klass/sql/KlassData.kt
@@ -33,6 +33,7 @@ internal object KlassData {
         join $SCHEMA.$CLASS_SECTION as CS on C.$CID=CS.$CLASS_SECTION_CID and C.$CAL_TERM=CS.$CLASS_SECTION_CAL_TERM
         join $SCHEMA.$COURSE as CR on CR.$COURSE_ID=C.$CID
         where C.$CID=:$CID and C.$CAL_TERM=:$CAL_TERM
+        order by $SID
     """
 
     const val GET_CLASSES_QUERY = """

--- a/project/src/test/kotlin/org/ionproject/core/klass/KlassControllerTest.kt
+++ b/project/src/test/kotlin/org/ionproject/core/klass/KlassControllerTest.kt
@@ -21,10 +21,10 @@ internal class KlassControllerTest : ControllerTester() {
             val calTerm = "1718v"
             return FullKlass(
                 cid, cacr, calTerm, sections = listOf(
-                    ClassSection(cid, cacr, calTerm, "1D"),
-                    ClassSection(cid, cacr, calTerm, "2D"),
-                    ClassSection(cid, cacr, calTerm, "1N")
-                )
+              ClassSection(cid, cacr, calTerm, "1D"),
+              ClassSection(cid, cacr, calTerm, "1N"),
+              ClassSection(cid, cacr, calTerm, "2D")
+            )
             )
         }
 


### PR DESCRIPTION
Closes #74 