### PR TITLE
JsonHome's ResourceBuilder refactor and HomeDocumentTest added.

### DIFF
--- a/project/src/main/kotlin/org/ionproject/core/home/JsonHomeController.kt
+++ b/project/src/main/kotlin/org/ionproject/core/home/JsonHomeController.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.util.UriTemplate
 import java.net.URI
 
 private const val specLocation = "https://github.com/i-on-project/core/tree/master/docs/api"
@@ -20,25 +19,31 @@ private const val apiName = "i-on Core"
 class JsonHomeController {
 
     @GetMapping("/")
-    fun getRoot(): ResponseEntity<JsonHome> =
-        ResponseEntity.ok(
-            JsonHomeBuilder(apiName)
-                .link("describedBy", specUri)
-                // course resource
-                .newResource("courses")
-                .hrefTemplate(UriTemplate("${Uri.forCourses()}${Uri.rfcPagingQuery}"))
-                .hrefVar("limit", URI("/api-docs/params/limit"))
-                .hrefVar("page", URI("/api-docs/params/page"))
-                .docs(coursesSpecUri)
-                .formats(Media.MEDIA_SIREN).allow(HttpMethod.GET)
-                .toResourceObject()
-                .newResource("calendar-terms")
-                .hrefTemplate(Uri.pagingCalendarTerms)
-                .hrefVar("limit", URI("/api-docs/params/limit"))
-                .hrefVar("page", URI("/api-docs/params/page"))
-                .docs(calendarTermsSpecUri)
-                .formats(Media.MEDIA_SIREN).allow(HttpMethod.GET)
-                .toResourceObject()
-                .toJsonHome()
-        )
+    fun getRoot(): ResponseEntity<JsonHome> {
+        val homeObject = JsonHomeBuilder(apiName)
+            .link("describedBy", specUri)
+            // courses resource
+            .newResource("courses") {
+                it
+                    .hrefTemplate(Uri.pagingCourses)
+                    .hrefVar("limit", URI("/api-docs/params/limit"))
+                    .hrefVar("page", URI("/api-docs/params/page"))
+                    .docs(coursesSpecUri)
+                    .formats(Media.MEDIA_SIREN).allow(HttpMethod.GET)
+                    .toResourceObject()
+            }
+            // calendar terms resource
+            .newResource("calendar-terms") {
+                it
+                    .hrefTemplate(Uri.pagingCalendarTerms)
+                    .hrefVar("limit", URI("/api-docs/params/limit"))
+                    .hrefVar("page", URI("/api-docs/params/page"))
+                    .docs(calendarTermsSpecUri)
+                    .formats(Media.MEDIA_SIREN).allow(HttpMethod.GET)
+                    .toResourceObject()
+            }
+            .toJsonHome()
+
+        return ResponseEntity.ok(homeObject)
+    }
 }

--- a/project/src/test/kotlin/org/ionproject/core/home/HomeDocumentTest.kt
+++ b/project/src/test/kotlin/org/ionproject/core/home/HomeDocumentTest.kt
@@ -1,0 +1,68 @@
+package org.ionproject.core.home
+
+import org.ionproject.core.utils.ControllerTester
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+internal class HomeDocumentTest : ControllerTester() {
+  companion object {
+    val expected = """{
+  "api" : {
+    "title" : "i-on Core",
+    "links" : {
+      "describedBy" : "https://github.com/i-on-project/core/tree/master/docs/api"
+    }
+  },
+  "resources" : {
+    "courses" : {
+      "hrefTemplate" : "/v0/courses{?page,limit}",
+      "hrefVars" : {
+        "limit" : "/api-docs/params/limit",
+        "page" : "/api-docs/params/page"
+      },
+      "hints" : {
+        "allow" : [ "GET" ],
+        "formats" : {
+          "application/vnd.siren+json" : { }
+        },
+        "docs" : "https://github.com/i-on-project/core/tree/master/docs/api/courses.md"
+      }
+    },
+    "calendar-terms" : {
+      "hrefTemplate" : "/v0/calendar-terms{?page,limit}",
+      "hrefVars" : {
+        "limit" : "/api-docs/params/limit",
+        "page" : "/api-docs/params/page"
+      },
+      "hints" : {
+        "allow" : [ "GET" ],
+        "formats" : {
+          "application/vnd.siren+json" : { }
+        },
+        "docs" : "https://github.com/i-on-project/core/tree/master/docs/api/calendar-terms.md"
+      }
+    }
+  }
+}"""
+  }
+
+  @Test
+  fun getHomeDocument() {
+    val body = doGet(URI.create("/"))
+      .andDo { print() }
+      .andExpect {
+        status { isOk }
+        content { contentType("application/json-home") }
+        jsonPath("$.api") { exists() }
+        jsonPath("$.resources") { exists() }
+        jsonPath("$.resources.courses") { exists() }
+        jsonPath("$.resources.calendar-terms") { exists() }
+      }
+      .andReturn()
+      .response
+      .contentAsString
+
+    Assertions.assertEquals(expected, body)
+  }
+}


### PR DESCRIPTION
- Adds missing home document test.
- creating a resource in the JsonHomeObject's resourceObject now has a clear scope when using the JsonHomeBuilder.
- changed `hrefTemplate` field of ResourceBuilder/Object from `String` to `UriTemplate`

Closes #115 