### PR TITLE
Bug: Fixed problem with one word strings in composite type

### DIFF
--- a/project/src/main/kotlin/org/ionproject/core/calendar/sql/CalendarComponentMapper.kt
+++ b/project/src/main/kotlin/org/ionproject/core/calendar/sql/CalendarComponentMapper.kt
@@ -147,11 +147,7 @@ class CalendarComponentMapper(
             val values = pgObject.split()
 
             val list = List(values.size) { idx ->
-                val str = values[idx]
-                if (str.startsAndEndsWith('"')) {
-                    str.removeSurrounding("\"")
-                }
-                str.replace("""\\""", """\""")
+                values[idx].removeSurrounding("\"").replace("""\\""", """\""")
             }
 
             map(list)

--- a/project/src/main/kotlin/org/ionproject/core/calendar/sql/CalendarComponentMapper.kt
+++ b/project/src/main/kotlin/org/ionproject/core/calendar/sql/CalendarComponentMapper.kt
@@ -109,6 +109,7 @@ class CalendarComponentMapper(
         return descriptions.toTypedArray()
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun ResultSet.getCategories(columnName: String): Array<Categories> {
         val tempCats = getArray(columnName).array as Array<Int>
 
@@ -138,6 +139,7 @@ class CalendarComponentMapper(
         )
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun <R> ResultSet.getCompositeArray(columnName: String, map: (List<String>) -> R): List<R> {
         val array = getArray(columnName).array as Array<Any>
 
@@ -188,6 +190,7 @@ class CalendarComponentMapper(
         )
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun ResultSet.getAttachments(columnName: String): Array<Attachment> {
         val att = getArray(columnName).array as Array<String?>
 

--- a/project/src/main/kotlin/org/ionproject/core/calendar/sql/CalendarComponentMapper.kt
+++ b/project/src/main/kotlin/org/ionproject/core/calendar/sql/CalendarComponentMapper.kt
@@ -83,8 +83,8 @@ class CalendarComponentMapper(
 
     private fun ResultSet.getSummaries(columnName: String): Array<Summary> {
         val summaries = getCompositeArray(columnName) {
-            val summaryLanguage = it[0] as Int
-            val summary = it[1] as String
+            val summaryLanguage = it[0].toInt()
+            val summary = it[1]
 
             Summary(
                 summary,
@@ -97,8 +97,8 @@ class CalendarComponentMapper(
 
     private fun ResultSet.getDescriptions(columnName: String): Array<Description> {
         val descriptions = getCompositeArray(columnName) {
-            val descriptionLanguage = it[0] as Int
-            val description = it[1] as String
+            val descriptionLanguage = it[0].toInt()
+            val description = it[1]
 
             Description(
                 description,
@@ -138,7 +138,7 @@ class CalendarComponentMapper(
         )
     }
 
-    private fun <R> ResultSet.getCompositeArray(columnName: String, oper: (List<Any>) -> R): List<R> {
+    private fun <R> ResultSet.getCompositeArray(columnName: String, map: (List<String>) -> R): List<R> {
         val array = getArray(columnName).array as Array<Any>
 
         return array.map {
@@ -149,13 +149,12 @@ class CalendarComponentMapper(
             val list = List(values.size) { idx ->
                 val str = values[idx]
                 if (str.startsAndEndsWith('"')) {
-                    str.removeSurrounding("\"").replace("""\\""", """\""")
-                } else {
-                    str.toInt()
+                    str.removeSurrounding("\"")
                 }
+                str.replace("""\\""", """\""")
             }
 
-            oper(list)
+            map(list)
         }
     }
 


### PR DESCRIPTION
This may seem like a workaround, but since a string with just numbers is impossible to distinguish from an actual number, due to the lack of metadata, the server will need to decide when something should be a number instead of a string and parse it.

Closes #165 