### PR TITLE
Feature [Deploy]: Using docker-compose for deploy.

### DIFF
--- a/.docker/.gitignore
+++ b/.docker/.gitignore
@@ -1,0 +1,1 @@
+env_deploy

--- a/.docker/compose_deploy.yaml
+++ b/.docker/compose_deploy.yaml
@@ -1,0 +1,28 @@
+version: '3'
+# WARNING!
+# In order for this procedure to work, you need to run docker-compose
+# from the root of the project, such that PWD=<root of the repo folder>
+# e.g. cd <root of project> && docker-compose -f .docker/compose_deploy.yaml run --rm core-deploy
+#
+# Credentials. Create a file named `env_deploy` in this folder, with the contents:
+# GCP_KEY='<JSON key credentials>'
+# GCP_ZONE='<zone of the GCE instance>'
+# GCP_REPO='<GCR repository name>'
+# GCP_INSTANCE='<target GCE instance name>'
+# GCP_PROJECT_ID='<GCP project ID>'
+# GCP_ACCOUNT='<GCP service account's email>'
+# GCP_DB_INSTANCE='<GCP SQL connection instance name>'
+# DB_CON_STRING_SUFFIX='<real db name>?user=<username>&password=<user password>'
+# DEV_DB_CON_STRING_SUFFIX='<auxiliary db name>?user=<username>&password=<user password>'
+services:
+    core-deploy:
+      build:
+        context: ..
+        dockerfile: ./project/res/dockerfile_deploy
+      env_file: ./env_deploy
+      network_mode: host
+      working_dir: "${PWD}"
+      container_name: core-deploy-container
+      volumes:
+        - "${PWD}:${PWD}"
+        - "/var/run/docker.sock:/var/run/docker.sock"

--- a/.github/workflows/gcp_release_deploy.yaml
+++ b/.github/workflows/gcp_release_deploy.yaml
@@ -2,7 +2,7 @@ name: Continuous Deployment
 
 on:
   push:
-    branches-ignore:
+    branches:
       - release/*
 
 jobs:

--- a/.github/workflows/gcp_release_deploy.yaml
+++ b/.github/workflows/gcp_release_deploy.yaml
@@ -1,48 +1,20 @@
-name: Deploy Core on Google Compute Engine
+name: Continuous Deployment
 
 on:
   push:
-    branches:
+    branches-ignore:
       - release/*
-
-env:
-  GCP_PROJECT_ID: ${{ secrets.GCP_PROJ_ID }}
-  GCP_INSTANCE: core-instance
-  GCP_INSTANCE_ZONE: europe-west2-c
-  GCP_REPO: eu.gcr.io
-  IMAGE_NAME: core-release-img
-  SCHEMA_DIFF_IMG: schema-diff-img
-  DB_PROXY_PORT: 10025
-  DB_DEV_NAME: ${{ secrets.DB_DEV_NAME }}
-  DB_NAME: ${{ secrets.DB_NAME }}
-  DB_USER: ${{ secrets.DB_USER }}
-  DB_PASS: ${{ secrets.DB_PASS }}
-  DB_INSTANCE: ${{ secrets.DB_INSTANCE }}
 
 jobs:
   build:
-    name: Build and test
+    name: Continuous Integration
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Start DB and run tests
-        env:
-          JDBC_DATABASE_URL: ${{ secrets.LOCAL_JDBC_DATABASE_URL }}
-        working-directory: project
-        run: ./gradlew pgSetupDb test
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: reports-test
-          path: project/build/reports/tests/test/
-        if: always()
-
-      - name: Stop DB
-        working-directory: project
-        run: ./gradlew pgStop
-
+      - name: Build and test
+        run: docker-compose -f .docker/compose_ci.yaml run --rm core
   deploy:
     name: Deploy to GCE
     runs-on: ubuntu-latest
@@ -52,62 +24,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      # GCloud steps:
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-        with:
-          version: '286.0.0'
-          service_account_email: ${{ secrets.GCP_EMAIL }}
-          service_account_key: ${{ secrets.GCP_KEY }}
-
-      - name: gcloud set up
-        run: gcloud config set project $GCP_PROJECT_ID
-
-      - name: Configure docker auth
-        run: gcloud auth configure-docker
-
-      - name: Set DB Proxy
-        run: |
-          wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy &&\
-            chmod +x cloud_sql_proxy &&\
-            ./cloud_sql_proxy -instances=$DB_INSTANCE=tcp:$DB_PROXY_PORT &
-
-      - name: Schema Migration Attempt
-        working-directory: ./project/res/bin/schema_diff
-        run: |
-          docker build -t $SCHEMA_DIFF_IMG . &&\
-            docker run --rm --network="host" \
-              -e DEV_DB_URL="postgresql://localhost:$DB_PROXY_PORT/$DB_DEV_NAME?user=$DB_USER&password=$DB_PASS" \
-              -e DB_URL="postgresql://localhost:$DB_PROXY_PORT/$DB_NAME?user=$DB_USER&password=$DB_PASS" \
-              -v "$(pwd)/../docker:/mnt" \
-              $SCHEMA_DIFF_IMG apply
-
-      - name: Guarantee connection string refresh, in case this job is executed by a previous runner
-        working-directory: project
-        run: ./gradlew clean -p buildSrc
-
-      - name: Insert Issue Token
-        working-directory: project
-        run: JDBC_DATABASE_URL="jdbc:postgresql://localhost:$DB_PROXY_PORT/$DB_NAME?user=$DB_USER&password=$DB_PASS" ./gradlew pgInsertIssueToken
-
-      - name: Kill proxy
-        run: pkill cloud_sql_proxy
+      - name: Set env file for Docker Compose
+        env:
+          ENV_FILE_CONTENTS: ${{ secrets.DEPLOY_ENV }}
+        run: echo "$ENV_FILE_CONTENTS" > .docker/env_deploy
 
       # Docker steps:
-      - name: Rebuild docker image
-        working-directory: ./project
-        run: docker build -t $IMAGE_NAME .
-
-      - name: Tag image
-        run: |
-          docker tag $IMAGE_NAME $GCP_REPO/$GCP_PROJECT_ID/$IMAGE_NAME:gh-$GITHUB_SHA &&\
-            docker tag $IMAGE_NAME $GCP_REPO/$GCP_PROJECT_ID/$IMAGE_NAME:latest
-
-      - name: Push image
-        run: docker push $GCP_REPO/$GCP_PROJECT_ID/$IMAGE_NAME
-
-      # Issue commands to the GCE instances
-      - name: Deploy
-        run: |-
-          gcloud compute instances update-container "$GCP_INSTANCE" \
-            --zone "$GCP_INSTANCE_ZONE" \
-            --container-image "$GCP_REPO/$GCP_PROJECT_ID/$IMAGE_NAME:gh-$GITHUB_SHA"
+      - name: Docker Compose run deploy
+        run: docker-compose -f .docker/compose_deploy.yaml run --rm core-deploy

--- a/project/src/test/resources/bin/deploy
+++ b/project/src/test/resources/bin/deploy
@@ -33,14 +33,13 @@ auth_gcp() {
     # completely wipe the credentials file from the disk
     if [ -f "$key_file" ]; then
       printf "Wiping key file.\n"
-      key_file_size="$(du -b "$key_file" | awk '{print $1}')"
-      wipe_bs="512"
-      wipe_count="$(( (key_file_size / wipe_bs) + 5 ))"
-      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
-      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
-      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
-      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
-      dd if=/dev/zero of="$key_file" bs="$wipe_bs" count="$wipe_count"
+      key_file_size="$(du -k "$key_file" | awk '{print $1}')"
+      wipe_bs="1K"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$key_file_size"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$key_file_size"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$key_file_size"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$key_file_size"
+      dd if=/dev/zero of="$key_file" bs="$wipe_bs" count="$key_file_size"
       rm "$key_file"
     fi
   }

--- a/project/src/test/resources/bin/deploy
+++ b/project/src/test/resources/bin/deploy
@@ -1,0 +1,142 @@
+#!/bin/sh
+
+set -eu
+
+# Check for needed evvars
+if [ -z "$GCP_KEY" ] ||\
+  [ -z "$GCP_REPO" ] ||\
+  [ -z "$GCP_PROJECT_ID" ] ||\
+  [ -z "$GCP_ACCOUNT" ] ||\
+  [ -z "$GCP_ZONE" ] ||\
+  [ -z "$GCP_INSTANCE" ] ||\
+  [ -z "$GCP_DB_INSTANCE" ] ||\
+  [ -z "$DB_CON_STRING_SUFFIX" ] ||\
+  [ -z "$DEV_DB_CON_STRING_SUFFIX" ]; then
+  printf "You need to set the following environment variables:\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n" \
+    "GCP_KEY" \
+    "GCP_REPO" \
+    "GCP_ZONE" \
+    "GCP_PROJECT_ID" \
+    "GCP_ACCOUNT" \
+    "GCP_INSTANCE" \
+    "GCP_DB_INSTANCE" \
+    "DB_CON_STRING_SUFFIX" \
+    "DEV_DB_CON_STRING_SUFFIX"
+  exit 1
+fi
+
+# Will authenticate this environment with the GCP account
+# Configures docker to use GCP account for pushing images to the GCR
+auth_gcp() {
+  key_file="/tmp/key.json"
+  auth_gcp_clean() {
+    # completely wipe the credentials file from the disk
+    if [ -f "$key_file" ]; then
+      printf "Wiping key file.\n"
+      key_file_size="$(du -b "$key_file" | awk '{print $1}')"
+      wipe_bs="512"
+      wipe_count="$(( (key_file_size / wipe_bs) + 5 ))"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
+      dd if=/dev/urandom of="$key_file" bs="$wipe_bs" count="$wipe_count"
+      dd if=/dev/zero of="$key_file" bs="$wipe_bs" count="$wipe_count"
+      rm "$key_file"
+    fi
+  }
+  trap 'auth_gcp_clean' EXIT
+  trap 'auth_gcp_clean' HUP
+  trap 'auth_gcp_clean' TERM
+  trap 'auth_gcp_clean' INT
+  trap 'auth_gcp_clean' 1
+  trap 'auth_gcp_clean' 2
+  printf "%s\n" "$GCP_KEY" > "$key_file"
+  
+  gcloud auth activate-service-account "$GCP_ACCOUNT" --key-file="$key_file"
+  gcloud config set project "$GCP_PROJECT_ID"
+  printf "gcloud authenticated.\n"
+
+  # Docker config
+  echo "$GCP_KEY" | docker login -u _json_key --password-stdin "https://${GCP_REPO}"
+  printf "Docker authenticated.\n"
+  auth_gcp_clean
+}
+
+# Make an attempt to migrate the database's schema
+schema_migration() {
+  printf "Attempting to migrate DB schema...\n"
+  db_proxy_port="10025"
+  schema_diff_img="core-db-schema-diff"
+  db_con_string_prefix="postgresql://localhost:$db_proxy_port"
+  db_con_string="${db_con_string_prefix}/${DB_CON_STRING_SUFFIX}"
+  dev_db_con_string="${db_con_string_prefix}/${DEV_DB_CON_STRING_SUFFIX}"
+
+  wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
+  chmod +x cloud_sql_proxy
+  ./cloud_sql_proxy -instances="$GCP_DB_INSTANCE=tcp:$db_proxy_port" &
+  cloud_sql_proxy_pid="$!"
+
+  backup_dir="$(pwd)"
+  cd .docker/src/res/bin/schema_diff
+  docker build -t "$schema_diff_img" .
+  docker run --rm --network="host" \
+    -e DEV_DB_URL="$dev_db_con_string" \
+    -e DB_URL="$db_con_string" \
+    -v "$(pwd)/../../docker:/mnt" \
+    "$schema_diff_img" apply
+  cd "$backup_dir"
+
+  kill "$cloud_sql_proxy_pid"
+  rm cloud_sql_proxy
+  printf "Schema migrated successfully.\n"
+}
+
+# Generates a unique hash to identify this version of the server
+get_image_tag() {
+  head_location=".git/$(awk '{print $2}' <.git/HEAD)"
+  head_hash="$(cat "$head_location")"
+  if [ -z "$head_hash" ]; then
+    # could not read commit hash
+    # gen random hash
+    head_hash="$(hexdump -n 16 -v -e '/1 "%02X"' -e '/16 "\n"' /dev/urandom)"
+  else
+    head_hash="gh-${head_hash}"
+  fi
+  printf "Using hash %s as the docker image tag.\n" "$head_hash"
+}
+
+# Builds the server/client and everything else
+# Pushes the fresh new images to GCR
+# $1 -> docker image name
+# $2 -> remote docker image name
+# $3 -> docker image tag
+docker_build_push() {
+  printf "Building docker image and pushing to GCR...\n"
+  docker build -f ./project/res/dockerfile_assemble ./project -t "$1"
+  docker tag "$1" "${2}:${3}"
+  docker tag "$1" "${2}:latest"
+  docker push "$2"
+  printf "Docker image built and pushed to GCR.\n"
+}
+
+# $1 -> remote docker image name + tag for the new version of the server
+notify_gcp() {
+  printf "Refreshing container of the GCE instance...\n"
+  gcloud compute instances update-container "$GCP_INSTANCE" \
+    --zone "$GCP_ZONE" \
+    --container-image "$1" 
+}
+
+auth_gcp
+
+schema_migration
+
+# Sets the head_hash variable
+get_image_tag
+
+image_name="core-release-img"
+gcr_image="${GCP_REPO}/${GCP_PROJECT_ID}/${image_name}"
+docker_build_push "$image_name" "$gcr_image" "$head_hash"
+
+notify_gcp "${gcr_image}:${head_hash}"
+

--- a/project/src/test/resources/bin/schema_diff/sdiff
+++ b/project/src/test/resources/bin/schema_diff/sdiff
@@ -4,6 +4,26 @@
 # Evvar $DEV_DB_URL -> URL to the dev DB
 # Evvar $DB_URL     -> URL to the release DB
 
+# Poll for DB availability
+# 1 minute of timeout
+timeout=60
+start_time="$(date +%s)"
+printf "Attempting to connect to the database...\\n"
+while true; do
+  if psql -Atx "$DEV_DB_URL" -1 -c "select" >/dev/null 2>/dev/null; then
+    printf "Connection established with the database.\\n"
+    break
+  fi
+  printf "DB unavailable. Retrying...\\n"
+
+  current_time="$(date +%s)"
+  if [ "$(( current_time - start_time ))" -ge "$timeout" ]; then
+    printf "Timeout reached. Exiting...\\n"
+    exit 1
+  fi
+  sleep 1
+done
+
 set -e
 
 schema_diff_file="/tmp/schema_diff"
@@ -19,7 +39,7 @@ cat "${scripts_dir}/drop-schema.sql" "${scripts_dir}/create-schema.sql" |\
 
 # Gen schema diff
 printf "\\set ON_ERROR_STOP on\n" >"$schema_diff_file"
-migra --unsafe "$DB_URL" "$DEV_DB_URL" | tee -a "$schema_diff_file"
+migra "$DB_URL" "$DEV_DB_URL" | tee -a "$schema_diff_file"
 
 if [ -n "$1" ] && [ "$1" = "apply" ]; then
     psql -Atx "$DB_URL" -1 -f "$schema_diff_file" >&2

--- a/project/src/test/resources/dockerfile_deploy
+++ b/project/src/test/resources/dockerfile_deploy
@@ -1,0 +1,4 @@
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+
+COPY . .
+ENTRYPOINT [ "./project/res/bin/deploy" ]


### PR DESCRIPTION
- You can deploy locally by running the command `docker-compose -f .docker/compose_deploy.yaml run --rm core-deploy`
  - You need to create a file named `env_deploy` in the `.docker` directory. The files contents are described in the `.docker/compose_deploy.yaml` file's comments
  - You MUST run this command from the root of the repository. Otherwise, it will fail.
- GH Actions will use `docker-compose` instead of executing all the deploy steps separately

closes #203 #200 