### PR TITLE
[Write API]: Make JSON Schema less restrictive.

### DIFF
--- a/docs/api/write/insertClassSectionEvents.md
+++ b/docs/api/write/insertClassSectionEvents.md
@@ -39,12 +39,12 @@ Properties marked with the quote "consult [#Constants](#constants) for the avail
     - *string* type
     - extensive name of
     - minimum number of characters: 2
-    - maximum number of characters: 50
+    - maximum number of characters: 100
     - e.g. `Instituto Superior de Engenharia de Lisboa`
 * `acr`
     - *string* type
     - acronym 
-    - minimum number of characters: 2
+    - minimum number of characters: 1
     - maximum number of characters: 10
     - e.g. `ISEL`
 * **required**
@@ -55,13 +55,13 @@ Properties marked with the quote "consult [#Constants](#constants) for the avail
 * `name`
     - *string* type
     - extensive name of 
-    - minimum number of characters: 2
-    - maximum number of characters: 50
+    - minimum number of characters: 1
+    - maximum number of characters: 100
     - e.g. `Licenciatura de Engenharia de Lisboa`
 * `acr`
     - *string* type
     - acronym
-    - minimum number of characters: 2
+    - minimum number of characters: 1
     - maximum number of characters: 10
     - e.g. `LEIC`
 * **required**

--- a/project/src/main/kotlin/org/ionproject/core/writeApi/insertClassSectionEvents/json/SchemaValidator.kt
+++ b/project/src/main/kotlin/org/ionproject/core/writeApi/insertClassSectionEvents/json/SchemaValidator.kt
@@ -14,11 +14,11 @@ private const val insertClassSectionEventsSchema = """{
         "name": {
           "type": "string",
           "minLength": 2,
-          "maxLength": 50
+          "maxLength": 100
         },
         "acr": {
           "type": "string",
-          "minLength": 2,
+          "minLength": 1,
           "maxLength": 10
         }
       },


### PR DESCRIPTION
- `name` has maximum of 100 characters
- `acr` has a minimum of 1 character

closes #208 