### PR TITLE
Refactor deployment procedure

### DIFF
--- a/.docker/.gitignore
+++ b/.docker/.gitignore
@@ -1,2 +1,1 @@
-env_deploy
-env_schema_diff
+env_*

--- a/.docker/compose_deploy.yaml
+++ b/.docker/compose_deploy.yaml
@@ -5,24 +5,13 @@ version: '3'
 # e.g. cd <root of project> && docker-compose -f .docker/compose_deploy.yaml run --rm core-deploy
 #
 # Credentials. Create a file named `env_deploy` in this folder, with the contents:
-# GCP_KEY='<JSON key credentials>'
-# GCP_ZONE='<zone of the GCE instance>'
-# GCP_REPO='<GCR repository name>'
-# GCP_INSTANCE='<target GCE instance name>'
-# GCP_PROJECT_ID='<GCP project ID>'
-# GCP_ACCOUNT='<GCP service account's email>'
-# GCP_DB_INSTANCE='<GCP SQL connection instance name>'
-# DB_CON_STRING_SUFFIX='<real db name>?user=<username>&password=<user password>'
-# DEV_DB_CON_STRING_SUFFIX='<auxiliary db name>?user=<username>&password=<user password>'
+# DOCKER_USERNAME
+# DOCKER_PASSWORD
+
 services:
     core-deploy:
       build:
         context: ..
         dockerfile: ./project/res/dockerfile_deploy
       env_file: ./env_deploy
-      network_mode: host
-      working_dir: "${PWD}"
       container_name: core-deploy-container
-      volumes:
-        - "${PWD}:${PWD}"
-        - "/var/run/docker.sock:/var/run/docker.sock"

--- a/.docker/compose_run_prod.yaml
+++ b/.docker/compose_run_prod.yaml
@@ -1,0 +1,23 @@
+version: '3'
+# WARNING!
+# In order for this procedure to work, you need to run docker-compose
+# from the root of the project, such that PWD=<root of the repo folder>
+# e.g. cd <root of project> && docker-compose -f .docker/compose_deploy.yaml run --rm core-deploy
+#
+# Credentials. Create a file named `env_prod` in this folder, with the contents:
+# DB_HOST
+# DB_PORT
+# DB_DATABASE
+# DB_USER
+# DB_PASSWORD
+# ION_CORE_SECRET_KEY=t8abumA3JBJrd7q0LuN3nSzKGBfslOYb
+# ION_CORE_BASE_URL="localhost:8080"
+
+services:
+    ion-core-deployment:
+      image: xploitedd/ion-core-deployment:latest
+      env_file: ./env_prod
+      network_mode: host
+      container_name: ion-core-deployment
+      volumes:
+        - "/var/run/docker.sock:/var/run/docker.sock"

--- a/.github/workflows/docker_release_deploy.yaml
+++ b/.github/workflows/docker_release_deploy.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Build and test
         run: docker-compose -f .docker/compose_ci.yaml run --rm core
   deploy:
-    name: Deploy to GCE
+    name: Deploy to Docker Hub
     runs-on: ubuntu-latest
     needs: build
 

--- a/README.md
+++ b/README.md
@@ -28,20 +28,32 @@ $ docker-compose -f .docker/compose_ci.yaml down
 $
 $ # In case you don't feel like installing docker-compose, you may use its docker-image as such
 $ docker run --rm -it -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock docker/compose:1.24.0 -f .docker/compose_ci.yaml up --abort-on-container-exit core
-$
-$ # Run the server and database on two containers
-$ docker-compose -f .docker/compose_run.yaml up core
-$ 
-$ # Remove docker images and clean resources
-$ docker-compose -f .docker/compose_run.yaml down
 ```
 The process is similar to any other file on the `.docker` folder (e.g. `.docker/compose_deploy.yaml`).
+
+## Running i-on Core
+
+To run i-on core locally we can use the `compose_run` docker compose file:
+
+```sh
+$ # Run the server and database on two containers
+$ docker-compose -f .docker/compose_run.yaml up core
+```
+
+After running this command the i-on Core should be available on port `10023` and the database on port `10021`.
 
 The following tokens will be inserted to the database container, for ease of use:
 - Read: `l7kowOOkliu21oXxNpuCyM47u2omkysxb8lv3qEhm5U`
 - Write: `hfk0DXJ9LIPuhvrjDEmhYRv5Z0YRhOl1DMEEPIp42ok`
 - Issue: `vUG-N_m_xVohFrnXcu2Jmt_KAeKfxQXV2LkLjJF4144`
 - Revoke: `5eN-N7muBGix6X0N8jfau7Ou-3KcNHPAGVZNGWQ6ryw`
+
+To clean up the core and database containers we can use docker compose again:
+
+```sh
+$ # Remove docker images and clean resources
+$ docker-compose -f .docker/compose_run.yaml down
+```
 
 Build
 =====

--- a/project/src/test/resources/bin/build_image
+++ b/project/src/test/resources/bin/build_image
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+image_tag="${DOCKER_USERNAME}/ion-core-deployment:latest"
+
+docker build -f project/res/dockerfile_deploy_instance -t "${image_tag}" .
+docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+docker push "${image_tag}"

--- a/project/src/test/resources/bin/deploy
+++ b/project/src/test/resources/bin/deploy
@@ -3,143 +3,124 @@
 set -eu
 
 # Check for needed evvars
-if [ -z "$GCP_KEY" ] ||\
-  [ -z "$GCP_REPO" ] ||\
-  [ -z "$GCP_PROJECT_ID" ] ||\
-  [ -z "$GCP_ACCOUNT" ] ||\
-  [ -z "$GCP_ZONE" ] ||\
-  [ -z "$GCP_INSTANCE" ] ||\
-  [ -z "$GCP_DB_INSTANCE" ] ||\
-  [ -z "$DB_CON_STRING_SUFFIX" ] ||\
-  [ -z "$DEV_DB_CON_STRING_SUFFIX" ]; then
+if [ -z "$DB_HOST" ] ||\
+  [ -z "$DB_PORT" ] ||\
+  [ -z "$DB_DATABASE" ] ||\
+  [ -z "$DB_USER" ] ||\
+  [ -z "$DB_PASSWORD" ]; then
   printf "You need to set the following environment variables:\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n" \
-    "GCP_KEY" \
-    "GCP_REPO" \
-    "GCP_ZONE" \
-    "GCP_PROJECT_ID" \
-    "GCP_ACCOUNT" \
-    "GCP_INSTANCE" \
-    "GCP_DB_INSTANCE" \
-    "DB_CON_STRING_SUFFIX" \
-    "DEV_DB_CON_STRING_SUFFIX"
+    "DB_HOST" \
+    "DB_PORT" \
+    "DB_DATABASE" \
+    "DB_USER" \
+    "DB_PASSWORD"
   exit 1
 fi
 
-# A file with the GCP credentials is placed in a foreign machine
-# Erase every trace of the file in the HDD by filling the sectors with random data
-# DIY version of the `shred` command
-wipe_file() {
-  dd if=/dev/urandom of="$1" bs="$2" count="$3"
-  dd if=/dev/urandom of="$1" bs="$2" count="$3"
-  dd if=/dev/urandom of="$1" bs="$2" count="$3"
-  dd if=/dev/urandom of="$1" bs="$2" count="$3"
-  dd if=/dev/zero of="$1" bs="$2" count="$3"
-  rm "$1"
+core_image_name="ion-core"
+core_container_name="core-production"
+core_port="8080"
+
+stop_core() {
+  printf "Stopping core container\n"
+  docker stop ${core_container_name} 2>/dev/null || true
+  docker rm ${core_container_name} 2>/dev/null || true
+  printf "Core container has stopped\n"
 }
 
-# Will authenticate this environment with the GCP account
-# Configures docker to use GCP account for pushing images to the GCR
-auth_gcp() {
-  key_file="/tmp/key.json"
-  auth_gcp_clean() {
-    # completely wipe the credentials file from the disk
-    if [ -f "$key_file" ]; then
-      printf "Wiping key file.\n"
-      key_file_size="$(du -k "$key_file" | awk '{print $1}')"
-      wipe_bs="1K"
-      wipe_file "$key_file" "$wipe_bs" "$key_file_size"
-    fi
-  }
-  trap 'auth_gcp_clean' EXIT
-  printf "%s\n" "$GCP_KEY" > "$key_file"
-  
-  gcloud auth activate-service-account "$GCP_ACCOUNT" --key-file="$key_file"
-  gcloud config set project "$GCP_PROJECT_ID"
-  printf "gcloud authenticated.\n"
+build_core_image() {
+  printf "Building core image\n"
+  cd project
 
-  # Docker config
-  echo "$GCP_KEY" | docker login -u _json_key --password-stdin "https://${GCP_REPO}"
-  printf "Docker authenticated.\n"
-  auth_gcp_clean
+  docker build -f ./res/dockerfile_ci -t "${core_image_name}:latest" .
+
+  cd ..
+  printf "Core image built\n"
+}
+
+start_core_container() {
+  printf "Starting core container\n"
+
+  docker run --name ${core_container_name} \
+    -p "${core_port}:${core_port}" \
+    -e GRADLE_OPTIONS="-xtest" \
+    -e JDBC_DATABASE_URL="jdbc:${db_con_string}" \
+    -e ION_CORE_SECRET_KEY="${ION_CORE_SECRET_KEY}" \
+    -e ION_CORE_BASE_URL="${ION_CORE_BASE_URL}" \
+    -d "${core_image_name}:latest" run
+
+  printf "Core container has started and it'll be available on port ${core_port}\n"
 }
 
 # Make an attempt to migrate the database's schema
 schema_migration() {
   printf "Attempting to migrate DB schema...\n"
-  db_proxy_port="10025"
+
   schema_diff_img="core-db-schema-diff"
   schema_diff_dockerfile="dockerfile_schema_diff"
-  db_con_string_prefix="postgresql://localhost:$db_proxy_port"
-  db_con_string="${db_con_string_prefix}/${DB_CON_STRING_SUFFIX}"
-  dev_db_con_string="${db_con_string_prefix}/${DEV_DB_CON_STRING_SUFFIX}"
+  db_img="core-aux-db"
+  db_dockerfile="dockerfile_db"
 
-  wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O /tmp/cloud_sql_proxy
-  chmod +x /tmp/cloud_sql_proxy
-  /tmp/cloud_sql_proxy -instances="$GCP_DB_INSTANCE=tcp:$db_proxy_port" &
+  dev_db_user="migration"
+  dev_db_password="migration"
+  dev_db_database="core"
+  dev_db_port="10021"
+
+  db_con_string="postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USER}&password=${DB_PASSWORD}"
+  dev_db_con_string="postgresql://localhost:${dev_db_port}/${dev_db_database}?user=${dev_db_user}&password=${dev_db_password}"
+
+  stop_core
 
   backup_dir="$(pwd)"
   cd .docker/src/res
-  # TODO: Copy the sql scripts to the docker image on build time (i.e. don't use a mount point)
+
+  docker build -f "${db_dockerfile}" -t "${db_img}" .
+  docker run --rm \
+    --name dev-db \
+    -e POSTGRES_USER="${dev_db_user}" \
+    -e POSTGRES_PASSWORD="${dev_db_password}" \
+    -e POSTGRES_DB="${dev_db_database}" \
+    -p "${dev_db_port}:5432" \
+    -d "${db_img}"
+
   docker build -f "$schema_diff_dockerfile" -t "$schema_diff_img" .
   docker run --rm --network="host" \
     -e DEV_DB_URL="$dev_db_con_string" \
     -e DB_URL="$db_con_string" \
     "$schema_diff_img" apply
+
+  migra_success=$?
   cd "$backup_dir"
+  docker stop dev-db
 
-  pkill cloud_sql_proxy || true
-  rm /tmp/cloud_sql_proxy
-  printf "Schema migrated successfully.\n"
-}
-
-# Generates a unique hash to identify this version of the server
-get_image_tag() {
-  head_location=".git/$(awk '{print $2}' <.git/HEAD)"
-  head_hash="$(cat "$head_location")"
-  if [ -z "$head_hash" ]; then
-    # could not read commit hash
-    # gen random hash
-    head_hash="$(hexdump -n 16 -v -e '/1 "%02X"' -e '/16 "\n"' /dev/urandom)"
+  if [ $migra_success -eq 0 ]; then
+    printf "Schema migrated successfully.\n"
+    build_core_image
+    start_core_container
   else
-    head_hash="gh-${head_hash}"
+    printf "Error migrating schema.\n"
+    # TODO: trigger email notification
+    start_core_container
   fi
-  printf "Using hash %s as the docker image tag.\n" "$head_hash"
 }
 
-# Builds the server/client and everything else
-# Pushes the fresh new images to GCR
-# $1 -> docker image name
-# $2 -> remote docker image name
-# $3 -> docker image tag
-docker_build_push() {
-  printf "Building docker image and pushing to GCR...\n"
-  docker build -f ./project/res/dockerfile_assemble ./project -t "$1"
-  docker tag "$1" "${2}:${3}"
-  docker tag "$1" "${2}:latest"
-  docker push "$2"
-  printf "Docker image built and pushed to GCR.\n"
-}
-
-# $1 -> remote docker image name + tag for the new version of the server
-notify_gcp() {
-  printf "Refreshing container of the GCE instance...\n"
-  gcloud compute instances update-container "$GCP_INSTANCE" \
-    --zone "$GCP_ZONE" \
-    --container-image "$1" 
+deploy_watchtower() {
+  container_hash="$(basename $(cat /proc/1/cpuset))"
+  container_name="$(docker inspect --format='{{.Name}}' ${container_hash} | cut -c 2-)"
+  
+  docker run \
+    --name deploy-watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -d containrrr/watchtower "${container_name}" --interval 30 \
+    2>/dev/null || true
 }
 
 # ENTRYPOINT
-
-auth_gcp
-
 schema_migration
+deploy_watchtower
 
-# Sets the head_hash variable
-get_image_tag
+cleanup() {
+  exit 0
+}
 
-image_name="core-release-img"
-gcr_image="${GCP_REPO}/${GCP_PROJECT_ID}/${image_name}"
-docker_build_push "$image_name" "$gcr_image" "$head_hash"
-
-notify_gcp "${gcr_image}:${head_hash}"
-
+while : ; do sleep 1 ; done

--- a/project/src/test/resources/bin/poll_db_and_build
+++ b/project/src/test/resources/bin/poll_db_and_build
@@ -22,7 +22,7 @@ done
 # Gradle is very slow at starting the daemon
 # Since the CI process will not make use of it anyway, might as well disable it
 mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
-./gradlew build "${GRADLE_OPTIONS}" --stacktrace --no-daemon
+./gradlew build "${GRADLE_OPTIONS:-}" --stacktrace --no-daemon
 
 if [ $# -gt 0 ] && [ "$1" = "run" ]; then
   java -server \

--- a/project/src/test/resources/bin/poll_db_and_build
+++ b/project/src/test/resources/bin/poll_db_and_build
@@ -22,7 +22,7 @@ done
 # Gradle is very slow at starting the daemon
 # Since the CI process will not make use of it anyway, might as well disable it
 mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
-./gradlew build --stacktrace --no-daemon
+./gradlew build "${GRADLE_OPTIONS}" --stacktrace --no-daemon
 
 if [ $# -gt 0 ] && [ "$1" = "run" ]; then
   java -server \

--- a/project/src/test/resources/bin/poll_db_and_build
+++ b/project/src/test/resources/bin/poll_db_and_build
@@ -22,7 +22,8 @@ done
 # Gradle is very slow at starting the daemon
 # Since the CI process will not make use of it anyway, might as well disable it
 mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
-./gradlew build "${GRADLE_OPTIONS:-}" --stacktrace --no-daemon
+
+./gradlew "${GRADLE_OPTIONS:-clean}" build --stacktrace --no-daemon
 
 if [ $# -gt 0 ] && [ "$1" = "run" ]; then
   java -server \

--- a/project/src/test/resources/dockerfile_deploy
+++ b/project/src/test/resources/dockerfile_deploy
@@ -1,4 +1,4 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+FROM docker:latest
 
 COPY . .
-ENTRYPOINT [ "./project/res/bin/deploy" ]
+ENTRYPOINT [ "./project/res/bin/build_image" ]

--- a/project/src/test/resources/dockerfile_deploy_instance
+++ b/project/src/test/resources/dockerfile_deploy_instance
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+RUN apk update
+RUN apk upgrade
+RUN apk add docker docker-compose grep git
+
+COPY . .
+ENTRYPOINT [ "./project/res/bin/deploy" ]

--- a/project/src/test/resources/dockerfile_schema_diff
+++ b/project/src/test/resources/dockerfile_schema_diff
@@ -1,5 +1,5 @@
-FROM alpine
-RUN apk add --no-cache postgresql-client libc-dev python3-dev python3 postgresql-dev gcc py3-pip &&\
+FROM alpine:latest
+RUN apk add --no-cache postgresql-client libc-dev python3-dev python3 postgresql-dev gcc g++ py3-pip &&\
   pip install --no-cache-dir migra psycopg2-binary
 
 RUN apk del libc-dev postgresql-dev python3-dev gcc


### PR DESCRIPTION
Refactors the deployment procedure to be compatible with the new requisites.

We still need to create a docker hub organization to deploy the images to, or in alternative we can create our own docker registry. For now the scripts are fetching the image from the [xploitedd/ion-core-deployment](https://hub.docker.com/r/xploitedd/ion-core-deployment) docker hub repository.

Closes #288 